### PR TITLE
feat: add captcha click function

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -8,6 +8,15 @@ function clickEnabledBtnContainsText(text) {
     }
 }
 
+function addHcaptchaApi() {
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.src = 'https://hcaptcha.com/1/api.js?hl=zh-TW';
+    script.setAttribute('async', '');
+    script.setAttribute('defer', '');
+    document.head.appendChild(script);
+}
+
 let jobTextList = ['汁妹', '領取獎勵', '友好切磋'];
 
 function loopJob(jobText) {
@@ -25,6 +34,7 @@ function checkCaptcha() {
     setTimeout(function () {
         if (document.querySelectorAll('iframe').length > 0) {
             console.log('Captcha detected!');
+            hcaptcha.execute();
             new Notification(
                 '騙人的吧，又有 Captcha 了',
                 {'icon': 'https://i.imgur.com/qeoW9T5.png'});
@@ -35,6 +45,7 @@ function checkCaptcha() {
 
 (function () {
     Notification.requestPermission();
+    addHcaptchaApi();
     jobTextList.forEach(jobText => loopJob(jobText));
     checkCaptcha();
 })();


### PR DESCRIPTION
hcapcha 驗證可以透過 [這邊](https://blog.skk.moe/post/bypass-hcaptcha/) 的方式來增加cookie到瀏覽器中。

之後便可以使用 hcaptcha 官方提供的 [API](https://docs.hcaptcha.com/configuration#jsapi) 的`hcaptcha.execute`來自動完成 hcaptcha 驗證。

cookie好像有次數限制，目前不確定運作機制。但是可以透過重開瀏覽器、換IP、或跟hcapcha 請求新的cookie來解決。

要更穩定，應該可以直接透過JS去請求新的cookie來使用，但個人對JS不太熟悉，也已經懶了就沒有撰寫了XD